### PR TITLE
Change the word "sermon" to "recording" in the URLs SermonSpeaker re...

### DIFF
--- a/com_sermonspeaker/site/router.php
+++ b/com_sermonspeaker/site/router.php
@@ -6,7 +6,13 @@ function SermonspeakerBuildRoute(&$query){
 	$segments	= array();
 	$view		= '';
 	if (isset($query['view'])){
-		$segments[] = $query['view'];
+	    if ($query['view'] == 'sermon'){
+	        $segments[] = 'recording';
+	    }else if ($query['view'] == 'sermons'){
+	        $segments[] = 'recordings';
+	    }else{
+	        $segments[] = $query['view'];
+	    }
 		$view = $query['view'];
 		unset($query['view']);
 	} else {
@@ -26,7 +32,7 @@ function SermonspeakerBuildRoute(&$query){
 	if (isset($query['task'])){
 		$segments[] = str_replace('.', '_', $query['task']);
 		if (isset($query['type'])){
-			$segments[] = $query['type'];
+		    $segments[] = $query['type'];
 			unset($query['type']);
 		}
 		unset($query['task']);
@@ -75,7 +81,7 @@ function SermonspeakerParseRoute($segments){
 				$vars['month'] = (int)$segments[3];
 			}
 			break;
-		case 'sermons':
+		case 'sermons' || 'recordings':
 			$vars['view'] = 'sermons';
 			if (isset($segments[1]) && $segments[1]){
 				$vars['year'] = (int)$segments[1];
@@ -84,7 +90,7 @@ function SermonspeakerParseRoute($segments){
 				$vars['month'] = (int)$segments[2];
 			}
 			break;
-		case 'sermon':
+		case 'sermon' || 'recording':
 			$vars['view'] = 'sermon';
 			$id = explode(':', $segments[1]);
 			$vars['id'] = (int)$id[0];


### PR DESCRIPTION
...ads and writes

I'm a pastor and want SermonSpeaker to stay focused on sermons.  But it's useful for organizations other than churches too, so this change makes the SEF URLs appropriate for recordings which are not sermons.

This pull request's changeset is sufficient to serve my needs, but would change all SermonSpeaker URLs to say "recording" instead of "sermon," so it would probably not be good to integrate this pull request into SermonSpeaker as is.  To integrate it into SermonSpeaker correctly, I think what would be needed is to create a component configuration parameter to allow the user to set SermonSpeaker's URL "view" name, and set the default for that parameter to the string "sermon."  I haven't taken the time to create that configuration parameter yet, but perhaps I or someone else can do that in the future.

Edit:  I thought this pull request was sufficient for my needs, but now I see it contains a bug.  It causes the error message "Sorry, unfortunately I didn't find any Sermons" when I follow a single sermon link from the Latest Sermons module to the frontend component.
