### PR TITLE
filter filetypes for latest sermon view

### DIFF
--- a/com_sermonspeaker/site/models/sermon.php
+++ b/com_sermonspeaker/site/models/sermon.php
@@ -199,11 +199,26 @@ class SermonspeakerModelSermon extends JModelItem
 	 */
 	public function getLatest()
 	{
+		$app    = JFactory::getApplication();
+		$params = $app->getParams();
+
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
 
 		$query->select('id');
 		$query->from('#__sermon_sermons');
+
+		// Filter by filetype
+		$filetype = $params->get('filetype', '');
+		if ($filetype == 'video')
+		{
+			$query->where('videofile != ""');
+		}
+		elseif ($filetype == 'audio')
+		{
+			$query->where('audiofile != ""');
+		}
+
 		$query->order('sermon_date DESC');
 
 		$db->setQuery($query, 0, 1);


### PR DESCRIPTION
Hi Thomas,

I'm using the "latest sermon" menu option and found, that the filetype filter does not work in this case.
I want to link to the latest sermon, that also has an audio file attached (ignore sermons without audio).
I enabled the option with this fix. Now I can set the filetype filter to 'audio' and get what I want.
I thought you might want to pull this so I prepared a pull request for you.

Grüße
Frieder