### PR TITLE
hide play icon when there's no file to play

### DIFF
--- a/com_sermonspeaker/site/helpers/sermonspeaker.php
+++ b/com_sermonspeaker/site/helpers/sermonspeaker.php
@@ -352,7 +352,7 @@ class SermonspeakerHelperSermonspeaker
 		// Prepare play icon function
 		$options = array();
 
-		if ($icon)
+		if ($icon && ($item->audiofile || $item->videofile))
 		{
 			switch (self::$params->get('list_icon_function', 3))
 			{


### PR DESCRIPTION
Another small change to prevent users from trying to play a sermon if there's no audio or video attached.
In my opinion it's best to not show the play icon at all.