### PR TITLE
mod_related_sermons - Used Language String in the <name></name> Tag

### DIFF
--- a/mod_related_sermons/mod_related_sermons.xml
+++ b/mod_related_sermons/mod_related_sermons.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" version="3.4" client="site" method="upgrade">
-	<name>Related Sermons</name>
+	<name>MOD_RELATED_SERMONS</name>
 	<author>Thomas Hunziker</author>
 	<creationDate>2016-03-28</creationDate>
 	<copyright>© 2019</copyright>


### PR DESCRIPTION
Changed the <name>...</name> tag to use the language string instead of hard-coded value.

From:
<name>Related Sermons</name>

To:
<name>MOD_RELATED_SERMONS</name>