### PR TITLE
mod_sermonarchive - Used Language String in the <name></name> Tag

### DIFF
--- a/mod_sermonarchive/mod_sermonarchive.xml
+++ b/mod_sermonarchive/mod_sermonarchive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" version="3.5" client="site" method="upgrade">
-	<name>Sermons Archive</name>
+	<name>MOD_SERMONARCHIVE</name>
 	<author>Thomas Hunziker, Rajesh K</author>
 	<creationDate>2016-03-28</creationDate>
 	<copyright>© 2019</copyright>


### PR DESCRIPTION
Changed the <name>...</name> tag to use the language string instead of hard-coded value.

From:
<name>Sermons Archive</name>

To:
<name>MOD_SERMONARCHIVE</name>