### PR TITLE
mod_sermoncast - Used Language String in the <name></name> Tag

### DIFF
--- a/mod_sermoncast/mod_sermoncast.xml
+++ b/mod_sermoncast/mod_sermoncast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" version="3.4" client="site" method="upgrade">
-	<name>SermonCast</name>
+	<name>MOD_SERMONCAST</name>
 	<author>Thomas Hunziker, Martin Hess</author>
 	<creationDate>2016-09-30</creationDate>
 	<copyright>© 2019</copyright>


### PR DESCRIPTION
Changed the <name>...</name> tag to use the language string instead of hard-coded value.

From:
<name>SermonCast</name>

To:
<name>MOD_SERMONCAST</name>