### PR TITLE
plg_search_sermonspeaker - Used Language String in the <name></name> Tag

### DIFF
--- a/plg_search_sermonspeaker/sermonspeaker.xml
+++ b/plg_search_sermonspeaker/sermonspeaker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.7.0-beta1" type="plugin" group="search" method="upgrade">
-	<name>Search - SermonSpeaker</name>
+	<name>PLG_SEARCH_SERMONSPEAKER</name>
 	<author>Thomas Hunziker</author>
 	<creationDate>2017-01-24</creationDate>
 	<copyright>© 2019</copyright>


### PR DESCRIPTION
Changed the <name>...</name> tag to use the language string instead of hard-coded value.

From:
<name>Search - SermonSpeaker</name>

To:
<name>PLG_SEARCH_SERMONSPEAKER</name>