### PR TITLE
Use language strings instead of hard-coded values in xml

### DIFF
--- a/com_sermonspeaker/admin/language/en-GB/en-GB.com_sermonspeaker.ini
+++ b/com_sermonspeaker/admin/language/en-GB/en-GB.com_sermonspeaker.ini
@@ -346,6 +346,9 @@ COM_SERMONSPEAKER_TOOLS_IMPORT="Import sermons from 'Preach It'"
 COM_SERMONSPEAKER_DELETE_FILE="Delete file"
 COM_SERMONSPEAKER_FIELD_TYPE_LABEL="Type"
 COM_SERMONSPEAKER_FIELD_TYPE_DESC="Which file the feed should be showing. 'Auto' will be based on priority and availability. 'Audio' and 'Video' will show only the respective files, or none if missing."
+COM_SERMONSPEAKER_FIELD_TYPE_OPTION_AUTO="Auto"
+COM_SERMONSPEAKER_FIELD_TYPE_OPTION_AUDIO="Audio"
+COM_SERMONSPEAKER_FIELD_TYPE_OPTION_VIDEO="Video"
 
 ; New (or changed) with SermonSpeaker 4.4
 COM_SERMONSPEAKER_TOOLS_TIME="Adjust time in sermon date"

--- a/com_sermonspeaker/site/views/feed/tmpl/default.xml
+++ b/com_sermonspeaker/site/views/feed/tmpl/default.xml
@@ -14,9 +14,9 @@
 				   label="COM_SERMONSPEAKER_FIELD_TYPE_LABEL"
 				   description="COM_SERMONSPEAKER_FIELD_TYPE_DESC"
 				   default="">
-				<option value="">Auto</option>
-				<option value="audio">Audio</option>
-				<option value="video">Video</option>
+				<option value="">COM_SERMONSPEAKER_FIELD_TYPE_OPTION_AUTO</option>
+				<option value="audio">COM_SERMONSPEAKER_FIELD_TYPE_OPTION_AUDIO</option>
+				<option value="video">COM_SERMONSPEAKER_FIELD_TYPE_OPTION_VIDEO</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/mod_sermoncast/language/en-GB/en-GB.mod_sermoncast.ini
+++ b/mod_sermoncast/language/en-GB/en-GB.mod_sermoncast.ini
@@ -40,6 +40,9 @@ MOD_SERMONCAST_PARAM_MENUITEM_DESC="Choose a menu item that will be used for SEF
 ; New with SermonSpeaker 4.3
 MOD_SERMONCAST_FIELD_TYPE_LABEL="Type"
 MOD_SERMONCAST_FIELD_TYPE_DESC="Which file the feed should be showing. 'Auto' will be based on priority and availability. 'Audio' and 'Video' will show only the respective files, or none if missing."
+MOD_SERMONCAST_FIELD_TYPE_OPTION_AUTO="Auto"
+MOD_SERMONCAST_FIELD_TYPE_OPTION_AUDIO="Audio"
+MOD_SERMONCAST_FIELD_TYPE_OPTION_VIDEO="Video"
 
 ; New with module 5.1
 MOD_SERMONCAST_FIELD_LOGO_LABEL="Logo"

--- a/mod_sermoncast/mod_sermoncast.xml
+++ b/mod_sermoncast/mod_sermoncast.xml
@@ -36,9 +36,9 @@
 					label="MOD_SERMONCAST_FIELD_TYPE_LABEL" 
 					description="MOD_SERMONCAST_FIELD_TYPE_DESC"
 					default="">
-					<option value="">Auto</option>
-					<option value="audio">Audio</option>
-					<option value="video">Video</option>
+					<option value="">MOD_SERMONCAST_FIELD_TYPE_OPTION_AUTO</option>
+					<option value="audio">MOD_SERMONCAST_FIELD_TYPE_OPTION_AUDIO</option>
+					<option value="video">MOD_SERMONCAST_FIELD_TYPE_OPTION_VIDEO</option>
 				</field>
 				<field type="spacer" />
 				<field


### PR DESCRIPTION
In the file mod_sermoncast.xml, as shown below, the values such as Auto, Audio, and Video are hard-coded instead of using the language strings.

```
<field name="sc_type" type="list" 
					label="MOD_SERMONCAST_FIELD_TYPE_LABEL" 
					description="MOD_SERMONCAST_FIELD_TYPE_DESC"
					default="">
					<option value="">Auto</option>
					<option value="audio">Audio</option>
					<option value="video">Video</option>
				</field>
```

In the file default.xml, as shown below, the values such as Auto, Audio, and Video are hard-coded instead of using the language strings.

```
<field name="type" type="list"
				   label="COM_SERMONSPEAKER_FIELD_TYPE_LABEL"
				   description="COM_SERMONSPEAKER_FIELD_TYPE_DESC"
				   default="">
				<option value="">Auto</option>
				<option value="audio">Audio</option>
				<option value="video">Video</option>
			</field>
```

This PR will replace the hard-coded options "Auto", "Audio", and "Video" with the new language strings formed that would be consistent with similar implementations.