### PR TITLE
Page Header change in Administrator

### DIFF
--- a/com_sermonspeaker/admin/views/help/view.html.php
+++ b/com_sermonspeaker/admin/views/help/view.html.php
@@ -69,7 +69,7 @@ class SermonspeakerViewHelp extends JViewLegacy
 	protected function addToolbar()
 	{
 		$canDo = SermonspeakerHelper::getActions();
-		JToolbarHelper::title(JText::_('JHELP'), 'support sermonhelp');
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_MENU_HELP')), 'support sermonhelp');
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{

--- a/com_sermonspeaker/admin/views/languages/view.html.php
+++ b/com_sermonspeaker/admin/views/languages/view.html.php
@@ -139,7 +139,7 @@ class SermonspeakerViewLanguages extends JViewLegacy
 	protected function addToolbar()
 	{
 		$canDo = SermonspeakerHelper::getActions();
-		JToolbarHelper::title(JText::_('COM_SERMONSPEAKER_MAIN_LANGUAGES'), 'comments-2 languages');
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_MAIN_LANGUAGES')), 'comments-2 languages');
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{

--- a/com_sermonspeaker/admin/views/series/view.html.php
+++ b/com_sermonspeaker/admin/views/series/view.html.php
@@ -107,7 +107,7 @@ class SermonspeakerViewSeries extends JViewLegacy
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
 
-		JToolbarHelper::title(JText::_('COM_SERMONSPEAKER_SERIES_TITLE'), 'drawer-2 series');
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_SERIES_TITLE')), 'drawer-2 series');
 
 		if ($canDo->get('core.create'))
 		{

--- a/com_sermonspeaker/admin/views/sermons/view.html.php
+++ b/com_sermonspeaker/admin/views/sermons/view.html.php
@@ -115,8 +115,8 @@ class SermonspeakerViewSermons extends JViewLegacy
 
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
-
-		JToolbarHelper::title(JText::_('COM_SERMONSPEAKER_SERMONS_TITLE'), 'quote-3 sermons');
+		
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_SERMONS_TITLE')), 'quote-3 sermons');
 
 		if ($canDo->get('core.create'))
 		{

--- a/com_sermonspeaker/admin/views/speakers/view.html.php
+++ b/com_sermonspeaker/admin/views/speakers/view.html.php
@@ -107,7 +107,7 @@ class SermonspeakerViewSpeakers extends JViewLegacy
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
 
-		JToolbarHelper::title(JText::_('COM_SERMONSPEAKER_SPEAKERS_TITLE'), 'users speakers');
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_SPEAKERS_TITLE')), 'users speakers');
 
 		if ($canDo->get('core.create'))
 		{

--- a/com_sermonspeaker/admin/views/tools/view.html.php
+++ b/com_sermonspeaker/admin/views/tools/view.html.php
@@ -85,7 +85,7 @@ class SermonspeakerViewTools extends JViewLegacy
 	protected function addToolbar()
 	{
 		$canDo = SermonspeakerHelper::getActions();
-		JToolbarHelper::title(JText::_('COM_SERMONSPEAKER_MAIN_TOOLS'), 'tools');
+		JToolbarHelper::title(JText::_(JText::sprintf('COM_SERMONSPEAKER').': '.JText::sprintf('COM_SERMONSPEAKER_MAIN_TOOLS')), 'tools');
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{


### PR DESCRIPTION
The change would prefix the Page Header in the back-end administrator with the component's name.

For example, the header "Help" would show as "SermonSpeaker: Help", "Series" would show as "SermonSpeaker: Series", and so forth..

This is consistent with other page headers such as "SermonSpeaker: Categories" and "SermonSpeaker: Fields" that are created by core Joomla!

As SermonSpeaker is not a core Joomla! extension, making the header consistent with how core Joomla created page headers would be a good idea.

Note: Kindly modify the code, if there is an efficient way.
